### PR TITLE
Fix issue with duplicate records

### DIFF
--- a/src/brp_kennisgevingen/models.py
+++ b/src/brp_kennisgevingen/models.py
@@ -24,6 +24,11 @@ class SubscriptionManager(models.Manager):
         today = timezone.now().date()
         return self.filter(Q(end_date__gt=today) | Q(end_date__isnull=True))
 
+    def updatable(self):
+        # Records which are updatable are either active or have a start date of today
+        today = timezone.now().date()
+        return self.filter(Q(end_date__gt=today) | Q(end_date__isnull=True) | Q(start_date=today))
+
     def create_with_bsn(
         self, application_id: str, bsn: str, start_date: date, end_date: date | None = None
     ):


### PR DESCRIPTION
When creating, removing and re-enabling a record on the same day a duplicate record was being created resulting in a IntegrityError. This has been fixed by changing the query used when updating records to also include inactive records with a start date of today.