### PR TITLE
Fix openapi workflow

### DIFF
--- a/.github/workflows/test-open-api-spec.yml
+++ b/.github/workflows/test-open-api-spec.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         mkdir spectral
         # Create spectral config file
-        echo 'extends: ["spectral:oas", "https://static.developer.overheid.nl/adr/ruleset.yaml"]' > ./spectral/.spectral.yaml
+        echo 'extends: ["https://static.developer.overheid.nl/adr/ruleset.yaml"]' > ./spectral/.spectral.yaml
 
         docker compose exec web curl -q -o /dev/null --silent --retry-connrefused --retry 5 --retry-delay 1 --fail http://web:8000/kennisgevingen/v1
 

--- a/.github/workflows/test-open-api-spec.yml
+++ b/.github/workflows/test-open-api-spec.yml
@@ -34,8 +34,11 @@ jobs:
 
         docker compose exec web curl 'http://web:8000/kennisgevingen/v1/openapi.yaml'  > ./spectral/openapi.yaml
 
+    - name: Setup spectral
+      run: npm install -g @stoplight/spectral-cli
+
     - name: Run spectral tests
-      run: docker run -v ./spectral:/mnt/spectral stoplight/spectral lint /mnt/spectral/openapi.yaml --ruleset /mnt/spectral/.spectral.yaml
+      run: spectral lint ./spectral/openapi.yaml --ruleset ./spectral/.spectral.yaml
 
     - name: Stop containers
       if: always()

--- a/src/brp_kennisgevingen/openapi/postprocessors.py
+++ b/src/brp_kennisgevingen/openapi/postprocessors.py
@@ -1,0 +1,20 @@
+def postprocessing_add_openapi_cors_header(result, generator, request, public):
+    responses = (
+        result.get("paths", {}).get("/openapi.json", {}).get("get", {}).get("responses", {})
+    )
+    openapi_json_response = responses.get("200")
+    if openapi_json_response is None:
+        return result
+
+    headers = openapi_json_response.setdefault("headers", {})
+    headers.setdefault(
+        "access-control-allow-origin",
+        {
+            "description": "Allows the OpenAPI document to be fetched cross-origin.",
+            "schema": {
+                "type": "string",
+                "enum": ["*"],
+            },
+        },
+    )
+    return result

--- a/src/brp_kennisgevingen/openapi/preprocessors.py
+++ b/src/brp_kennisgevingen/openapi/preprocessors.py
@@ -4,6 +4,6 @@ import re
 def preprocessing_filter_spec(endpoints):
     filtered = []
     for path, path_regex, method, callbacks in endpoints:
-        if not re.match(r"(.+v1$)|(.+/openapi)", path):
+        if not re.match(r"(.+v1$)|(.+/openapi\.yaml)", path):
             filtered.append((path, path_regex, method, callbacks))
     return filtered

--- a/src/brp_kennisgevingen/settings.py
+++ b/src/brp_kennisgevingen/settings.py
@@ -357,7 +357,11 @@ keer wijzigingen waren gevraagd. Voor elk burgerservicenummer in de response
 SPECTACULAR_SETTINGS = {
     "TITLE": "BRP Kennisgevingen API",
     "DESCRIPTION": SPECTACULAR_DESCRIPTION,
-    "CONTACT": {"email": "datapunt@amsterdam.nl"},
+    "CONTACT": {
+        "email": "datapunt@amsterdam.nl",
+        "name": "Datapunt Amsterdam",
+        "url": "https://www.amsterdam.nl/",
+    },
     "VERSION": "1.0.0",
     "LICENSE": {
         "name": "European Union Public License, version 1.2 (EUPL-1.2)",
@@ -365,11 +369,30 @@ SPECTACULAR_SETTINGS = {
     },
     "SCHEMA_PATH_PREFIX": "/kennisgevingen/v1",
     "SCHEMA_PATH_PREFIX_TRIM": True,
+    "SERVERS": [
+        {
+            "url": "https://api.brp.amsterdam.nl/kennisgevingen/v1",
+            "description": "Productieomgeving",
+        },
+        {
+            "url": "https://acc.api.brp.amsterdam.nl/kennisgevingen/v1",
+            "description": "Acceptatieomgeving",
+        },
+        {
+            "url": "https://brp.data-t.azure.amsterdam.nl/kennisgevingen/v1",
+            "description": "Testomgeving",
+        },
+        {
+            "url": "https://brp.data-o.azure.amsterdam.nl/kennisgevingen/v1",
+            "description": "Ontwikkelomgeving",
+        },
+    ],
     "AUTHENTICATION_WHITELIST": None,
     "PREPROCESSING_HOOKS": [
         "brp_kennisgevingen.openapi.preprocessors.preprocessing_filter_spec",
     ],
     "TAGS": [
+        {"name": "bsn-wijzigingen"},
         {"name": "Beheren volgindicaties"},
         {"name": "Raadplegen wijzigingen"},
     ],

--- a/src/brp_kennisgevingen/settings.py
+++ b/src/brp_kennisgevingen/settings.py
@@ -391,6 +391,9 @@ SPECTACULAR_SETTINGS = {
     "PREPROCESSING_HOOKS": [
         "brp_kennisgevingen.openapi.preprocessors.preprocessing_filter_spec",
     ],
+    "POSTPROCESSING_HOOKS": [
+        "brp_kennisgevingen.openapi.postprocessors.postprocessing_add_openapi_cors_header",
+    ],
     "TAGS": [
         {"name": "bsn-wijzigingen"},
         {"name": "Beheren volgindicaties"},

--- a/src/brp_kennisgevingen/settings.py
+++ b/src/brp_kennisgevingen/settings.py
@@ -397,6 +397,7 @@ SPECTACULAR_SETTINGS = {
     "TAGS": [
         {"name": "bsn-wijzigingen"},
         {"name": "Beheren volgindicaties"},
+        {"name": "openapi.json"},
         {"name": "Raadplegen wijzigingen"},
     ],
 }


### PR DESCRIPTION
Moest wat dingen veranderen om de spectral action te laten passen.

Gefixte errors:
- /openapi.json path is verplicht
- /openapi.json moet access-control-allow-origin "*" hebben
- contact info moet url & name hebben

Gefixte warnings:
- ontbrekende tags toegevoegd aan global tags 